### PR TITLE
Downgrading openai lib to fix use by langchain

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,13 +1,13 @@
 python-dotenv==1.0.0
 pandas==2.0.1
-langchain==0.1.17
-openai==1.31.1
+openai==0.27.10
 pinecone-client==3.2.2
 tqdm==4.65.0
 sentence-transformers==2.2.2
 scikit-learn==1.2.2
 streamlit==1.33.0
 google-generativeai==0.5.2
+langchain==0.2.3
 langchain-google-genai==1.0.3
 langchain_pinecone==0.1.0
 beautifulsoup4==4.12.3


### PR DESCRIPTION
Langchain and Openai libraries are incompatible for certain version of both. The openai lib was downgraded to conciliate both libraries.